### PR TITLE
set matplotlib.font_manager logging level

### DIFF
--- a/storms/utils/plotter.py
+++ b/storms/utils/plotter.py
@@ -1,10 +1,11 @@
+import logging
+
+logging.getLogger("matplotlib.font_manager").setLevel(logging.WARNING)
+
 from geopandas import GeoSeries
 from matplotlib import pyplot as plt
 from matplotlib.cm import Spectral_r
 import os
-import logging
-
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
 
 def cluster_plot(xdata, cluster_geometry, vmin, vmax, scale_label, multiplier: int = 1, geom=None, png=None):


### PR DESCRIPTION
Removes "INFO:matplotlib.font_manager:generated new fontManager" from logs