### PR TITLE
Hotfix/improve logging

### DIFF
--- a/stormcloud/common/cloud.py
+++ b/stormcloud/common/cloud.py
@@ -55,9 +55,7 @@ def split_s3_path(s3_path: str) -> Tuple[str, str]:
     return bucket, key
 
 
-def load_watershed(
-    s3_bucket: str, s3_key: str, access_key_id: str, secret_access_key: str
-) -> Union[Polygon, MultiPolygon]:
+def load_aoi(s3_bucket: str, s3_key: str, access_key_id: str, secret_access_key: str) -> Union[Polygon, MultiPolygon]:
     """Loads watershed geometry from s3 resource
 
     Args:
@@ -72,9 +70,7 @@ def load_watershed(
     Returns:
         Union[Polygon, MultiPolygon]: shapely geometry pulled from watershed s3 geojson
     """
-    logging.info(
-        f"Loading watershed transposition region geometry from geojson s3://{s3_bucket}/{s3_key}"
-    )
+    logging.info(f"Loading watershed transposition region geometry from geojson s3://{s3_bucket}/{s3_key}")
     session = boto3.session.Session(access_key_id, secret_access_key)
     s3_client = session.client("s3")
     response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
@@ -82,9 +78,7 @@ def load_watershed(
     geojson_dict = json.loads(geojson_data)
     features = geojson_dict["features"]
     if len(features) > 1:
-        err = ValueError(
-            "More than one feature in watershed geojson, only expected one feature"
-        )
+        err = ValueError("More than one feature in watershed geojson, only expected one feature")
         logging.exception(err)
         raise err
     geometry_attribute = features[0]["geometry"]

--- a/stormcloud/common/dss.py
+++ b/stormcloud/common/dss.py
@@ -35,7 +35,7 @@ class DSSWriter:
         path_b: str,
         path_f: str,
         resolution: int,
-        verbose: bool = True,
+        verbose: bool = False,
         grid_type: str = "shg-time",
         cell_zero_xcoord: int = 0,
         cell_zero_ycoord: int = 0,
@@ -51,6 +51,7 @@ class DSSWriter:
         self.cell_zero_xcoord = cell_zero_xcoord
         self.cell_zero_ycoord = cell_zero_ycoord
         self.dss_file = None
+        self.records = 0
 
     def __enter__(self):
         if not self.print_pydss:
@@ -164,6 +165,7 @@ class DSSWriter:
         )
 
         self.dss_file.put_grid(path, data, grid_info)
+        self.records += 1
 
 
 def write_dss(

--- a/stormcloud/common/dss.py
+++ b/stormcloud/common/dss.py
@@ -92,7 +92,7 @@ class DSSWriter:
         self.dss_file.close()
 
     def write_data(self, xdata: xr.Dataset, labeled_variable_dict: Tuple[str, Dict[str, str]]):
-        logging.info("Writing data to dss")
+        logging.debug("Writing data to dss")
         if not self.dss_file:
             raise ValueError(
                 f"No dss file is open to receive data. Make sure that either context manager or open method is used before writing."
@@ -165,7 +165,16 @@ class DSSWriter:
 
         self.dss_file.put_grid(path, data, grid_info)
 
-def write_dss(xdata: xr.Dataset, data_variable_dict: Dict[str, Dict[str, str]], dss_path: str, path_a: str, path_b: str, path_f: str, resolution: int) -> None:
+
+def write_dss(
+    xdata: xr.Dataset,
+    data_variable_dict: Dict[str, Dict[str, str]],
+    dss_path: str,
+    path_a: str,
+    path_b: str,
+    path_f: str,
+    resolution: int,
+) -> None:
     with DSSWriter(dss_path, path_a, path_b, path_f, resolution) as writer:
         for labeled_variable_dict in data_variable_dict.items():
             for i, _ in enumerate(xdata.time.to_numpy()):

--- a/stormcloud/common/zarr.py
+++ b/stormcloud/common/zarr.py
@@ -68,7 +68,7 @@ def load_zarr(
     Returns:
         xr.Dataset: zarr dataset loaded to xarray dataset
     """
-    logging.info(f"Loading .zarr dataset from s3://{s3_bucket}/{s3_key}")
+    logging.debug(f"Loading .zarr dataset from s3://{s3_bucket}/{s3_key}")
     s3 = s3fs.S3FileSystem(key=access_key_id, secret=secret_access_key)
     ds = xr.open_zarr(s3fs.S3Map(f"{s3_bucket}/{s3_key}", s3=s3))
     if data_variables:
@@ -140,6 +140,8 @@ def extract_period_zarr(
                 raise ValueError(
                     f"Data variable within provided data variables ({data_variables}) does not have s3 data tracked by Dewberry: {data_variable}"
                 )
+            if current_dt.hour == 0:
+                logging.info(f"Loading data from s3://{zarr_bucket}/{zarr_key}")
             zarr_key = f"{zarr_key_prefix}/{current_dt.year}/{current_dt.strftime('%Y%m%d%H')}.zarr"
             hour_ds = load_zarr(zarr_bucket, zarr_key, access_key_id, secret_access_key)
             hour_ds.rio.write_crs("epsg:4326", inplace=True)

--- a/stormcloud/common/zarr.py
+++ b/stormcloud/common/zarr.py
@@ -7,8 +7,7 @@ from typing import Iterator, List, Tuple, Union
 import s3fs
 import xarray as xr
 from shapely.geometry import MultiPolygon, Polygon
-
-from .cloud import load_watershed
+from zarr.errors import GroupNotFoundError
 
 
 class NOAADataVariable(enum.Enum):
@@ -55,7 +54,7 @@ def load_zarr(
     access_key_id: str,
     secret_access_key: str,
     data_variables: Union[List[str], None] = None,
-) -> xr.Dataset:
+) -> Union[xr.Dataset, None]:
     """Load zarr data from s3
 
     Args:
@@ -69,12 +68,16 @@ def load_zarr(
         xr.Dataset: zarr dataset loaded to xarray dataset
     """
     logging.debug(f"Loading .zarr dataset from s3://{s3_bucket}/{s3_key}")
-    s3 = s3fs.S3FileSystem(key=access_key_id, secret=secret_access_key)
-    ds = xr.open_zarr(s3fs.S3Map(f"{s3_bucket}/{s3_key}", s3=s3))
-    if data_variables:
-        logging.info(f"Subsetting dataset to data variables of interest: {', '.join(data_variables)}")
-        ds = ds[data_variables]
-    return ds
+    try:
+        s3 = s3fs.S3FileSystem(key=access_key_id, secret=secret_access_key)
+        ds = xr.open_zarr(s3fs.S3Map(f"{s3_bucket}/{s3_key}", s3=s3))
+        if data_variables:
+            logging.debug(f"Subsetting dataset to data variables of interest: {', '.join(data_variables)}")
+            ds = ds[data_variables]
+        return ds
+    except GroupNotFoundError:
+        logging.warning(f"Failed to load .zarr dataset from s3://{s3_bucket}/{s3_key}; key '{s3_key}' may not exist")
+        return None
 
 
 def trim_dataset(
@@ -108,29 +111,25 @@ def extract_period_zarr(
     end_dt: datetime.datetime,
     data_variables: List[NOAADataVariable],
     zarr_bucket: str,
-    geojson_bucket: str,
-    geojson_key: str,
+    aoi_shape: Union[Polygon, MultiPolygon],
     access_key_id: str,
     secret_access_key: str,
 ) -> Iterator[Tuple[xr.Dataset, NOAADataVariable]]:
-    """Extracts zarr data for a specified watershed and transposition region over a specified period
+    """Extracts zarr data for a specified area of interest over a specified period
 
     Args:
-        watershed_name (str): Watershed of interest
-        domain_name (str): Transposition region
         start_dt (datetime.datetime): Start of period to extract
         end_dt (datetime.datetime): End of period to extract
         data_variables (List[NOAADataVariable]): List of data variables
         zarr_bucket (str): s3 bucket holding zarr data
-        geojson_bucket (str): s3 geojson bucket
-        geojson_key (str): s3 geojson key
+        aoi_shape: (Union[Polygon, MultiPolygon]): Shapely geometry of area of interest for extraction
         access_key_id (str): s3 access key ID
         secret_access_key (str): s3 secret access key
     """
     current_dt = start_dt
-    watershed_shape = load_watershed(geojson_bucket, geojson_key, access_key_id, secret_access_key)
     while current_dt < end_dt:
-        current_dt += datetime.timedelta(hours=1)
+        if current_dt.hour == 0:
+            logging.info(f"Loading data for {current_dt}")
         for data_variable in data_variables:
             if data_variable == NOAADataVariable.APCP:
                 zarr_key_prefix = "transforms/aorc/precipitation"
@@ -140,10 +139,11 @@ def extract_period_zarr(
                 raise ValueError(
                     f"Data variable within provided data variables ({data_variables}) does not have s3 data tracked by Dewberry: {data_variable}"
                 )
-            if current_dt.hour == 0:
-                logging.info(f"Loading data from s3://{zarr_bucket}/{zarr_key}")
+
             zarr_key = f"{zarr_key_prefix}/{current_dt.year}/{current_dt.strftime('%Y%m%d%H')}.zarr"
             hour_ds = load_zarr(zarr_bucket, zarr_key, access_key_id, secret_access_key)
-            hour_ds.rio.write_crs("epsg:4326", inplace=True)
-            watershed_hour_ds = hour_ds.rio.clip([watershed_shape], drop=True, all_touched=True)
-            yield watershed_hour_ds, data_variable
+            if hour_ds:
+                hour_ds.rio.write_crs("epsg:4326", inplace=True)
+                watershed_hour_ds = hour_ds.rio.clip([aoi_shape], drop=True, all_touched=True)
+                yield watershed_hour_ds, data_variable
+        current_dt += datetime.timedelta(hours=1)

--- a/stormcloud/plugins/temp_precip/temp_precip.yaml
+++ b/stormcloud/plugins/temp_precip/temp_precip.yaml
@@ -108,7 +108,7 @@ inputs:
     maxOccurs: 1
   - id: write_interval
     title: write interval
-    description: interval at which DSS files should be written out
+    description: interval at which DSS files should be written out, valid choices -- ["year", "month", "week", "hour"], defaults to month of none provided
     input:
       literalDataDomain:
         dataType: value

--- a/stormcloud/plugins/temp_precip/temp_precip_plugin.py
+++ b/stormcloud/plugins/temp_precip/temp_precip_plugin.py
@@ -7,13 +7,9 @@ import os
 from tempfile import TemporaryDirectory
 
 import boto3
+from common.cloud import create_presigned_url, split_s3_path
 from dotenv import load_dotenv
-from write_aorc_zarr_to_dss import (
-    SpecifiedInterval,
-    ZarrExtractionInput,
-    generate_dss_from_zarr,
-)
-from common.cloud import split_s3_path, create_presigned_url
+from write_aorc_zarr_to_dss import SpecifiedInterval, ZarrExtractionInput, generate_dss_from_zarr
 
 PLUGIN_PARAMS = {
     "required": [
@@ -52,9 +48,7 @@ def main(params: dict) -> dict:
         params["zarr_s3_bucket"],
     )
 
-    session = boto3.session.Session(
-        access_key_id, secret_access_key, region_name=aws_region
-    )
+    session = boto3.session.Session(access_key_id, secret_access_key, region_name=aws_region)
     s3_client = session.client("s3")
 
     result_list = []
@@ -94,7 +88,7 @@ def main(params: dict) -> dict:
 
     result_dict["results"] = result_list
     ref_links = []
-    # Add presigne urls
+    # Add presigned urls
     for key in result_list:
         bucket, s3_key = split_s3_path(key)
         ref_links.append(

--- a/stormcloud/write_aorc_zarr_to_dss.py
+++ b/stormcloud/write_aorc_zarr_to_dss.py
@@ -20,6 +20,7 @@ class SpecifiedInterval(enum.Enum):
     DAY = enum.auto()
     WEEK = enum.auto()
     MONTH = enum.auto()
+    YEAR = enum.auto()
 
 
 @dataclass
@@ -90,7 +91,9 @@ def generate_dss_from_zarr(
 ) -> Iterator[Tuple[str, str]]:
     current_dt = start_dt
     while current_dt < end_dt:
-        if write_interval == SpecifiedInterval.MONTH:
+        if write_interval == SpecifiedInterval.YEAR:
+            current_dt_next = current_dt.replace(year=current_dt.year + 1)
+        elif write_interval == SpecifiedInterval.MONTH:
             current_dt_next = current_dt.replace(month=current_dt.month + 1)
         elif write_interval == SpecifiedInterval.WEEK:
             current_dt_next = current_dt + datetime.timedelta(days=7)
@@ -199,14 +202,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--write_interval",
         type=str,
-        choices=["month", "week", "day"],
+        choices=["year", "month", "week", "day"],
         default="month",
-        help="Interval at which DSS files will be written out",
+        help="Interval at which DSS files will be written out. Defaults to month.",
     )
 
     args = parser.parse_args()
 
-    if args.write_interval == "month":
+    if args.write_interval == "year":
+        interval = SpecifiedInterval.YEAR
+    elif args.write_interval == "month":
         interval = SpecifiedInterval.MONTH
     elif args.write_interval == "week":
         interval = SpecifiedInterval.WEEK


### PR DESCRIPTION
- generalizes load_watershed function to load_aoi
- loads aoi only once per plugin call instead of once for every writing session
- adds daily logger for data loading, effectively replacing hourly logger
- fixes datetime iteration error in dataset trimming
- logs warning for hourly s3 data missing and skips instead of failing
- changes level of hourly logs showing data load progress to debug
- changes verbose option on writer from default true to false
- adds year write interval option